### PR TITLE
Correct issues with default theme on zsh

### DIFF
--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -34,6 +34,7 @@ define_helpers() {
   NewLine="\n"
 
   if [ -n "$ZSH_VERSION" ]; then
+    Time12a="%T"
     PathShort="%~"
     NewLine=$'\n'
   fi
@@ -87,8 +88,8 @@ define_undefined_git_prompt_colors() {
   # _LAST_COMMAND_INDICATOR_ will be replaced by the appropriate GIT_PROMPT_COMMAND_OK OR GIT_PROMPT_COMMAND_FAIL
   if [ -z "${GIT_PROMPT_START_USER+x}" ]; then GIT_PROMPT_START_USER="_LAST_COMMAND_INDICATOR_ ${Yellow}${PathShort}${ResetColor}"; fi
   if [ -z "${GIT_PROMPT_START_ROOT+x}" ]; then GIT_PROMPT_START_ROOT="${GIT_PROMPT_START_USER}"; fi
-  if [ -z "${GIT_PROMPT_END_USER+x}" ]; then GIT_PROMPT_END_USER=" \n${White}${Time12a}${ResetColor} $ "; fi
-  if [ -z "${GIT_PROMPT_END_ROOT+x}" ]; then GIT_PROMPT_END_ROOT=" \n${White}${Time12a}${ResetColor} # "; fi
+  if [ -z "${GIT_PROMPT_END_USER+x}" ]; then GIT_PROMPT_END_USER=" ${NewLine}${White}${Time12a}${ResetColor} $ "; fi
+  if [ -z "${GIT_PROMPT_END_ROOT+x}" ]; then GIT_PROMPT_END_ROOT=" ${NewLine}${White}${Time12a}${ResetColor} # "; fi
 
   # Please do not add colors to these symbols
   if [ -z ${GIT_PROMPT_SYMBOLS_AHEAD+x} ]; then GIT_PROMPT_SYMBOLS_AHEAD="↑·"; fi             # The symbol for "n versions ahead of origin"


### PR DESCRIPTION
- Use added `NewLine` variable for zsh-specific newline
- `Time12a` variant added for zsh